### PR TITLE
updated readme with linking to opencv libraries for building on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ to the `./samples` folder:
         cd ~/opencv-2.4.5/apps/haartraining
         g++ `pkg-config --libs --cflags opencv` -I. -o mergevec mergevec.cpp\
           cvboost.cpp cvcommon.cpp cvsamples.cpp cvhaarclassifier.cpp\
-          cvhaartraining.cpp
+          cvhaartraining.cpp\
+          -lopencv_core -lopencv_calib3d -lopencv_imgproc -lopencv_highgui -lopencv_objdetect
 
 7. Use the compiled executable `mergevec` to merge the samples in `./samples`
 into one file:


### PR DESCRIPTION
Adding the links for the library as shown allowed me to build mergevec on linux. I'm unfamiliar with mac so it would be nice if you could ensure it doesn't break compilation on there (however I don't think it should).
